### PR TITLE
added more symbols to forex.rb

### DIFF
--- a/bin/market_data
+++ b/bin/market_data
@@ -10,6 +10,7 @@ require 'ib-ruby'
 # Definition of what we want market data for.  We have to keep track of what ticker id
 # corresponds to what symbol ourselves, because the ticks don't include any other
 # identifying information. The choice of ticker ids is, as far as I can tell, arbitrary.
+# (note: the forex symbols used here MUST be defined in lib/ib/symbols/forex.rb)
 @market = {123 => IB::Symbols::Forex[:gbpusd],
            456 => IB::Symbols::Forex[:eurusd],
            789 => IB::Symbols::Forex[:usdcad]}

--- a/lib/ib/symbols/forex.rb
+++ b/lib/ib/symbols/forex.rb
@@ -8,13 +8,80 @@ module IB
       # used for smaller currency conversions.
       def self.contracts
         @contracts ||= {
-
-         :audchf => IB::Contract.new(:symbol => "AUD",
+          #-- major pairs (alphabetical order) --
+          :audusd => IB::Contract.new(:symbol => "AUD",
+                                      :exchange => "IDEALPRO",
+                                      :currency => "USD",
+                                      :sec_type => :forex,
+                                      :description => "AUDUSD"),
+                                      
+          :eurchf => IB::Contract.new(:symbol => "EUR",
+                                      :exchange => "IDEALPRO",
+                                      :currency => "CHF",
+                                      :sec_type => :forex,
+                                      :description => "EURCHF"),
+                                      
+          :eurgbp => IB::Contract.new(:symbol => "EUR",
+                                      :exchange => "IDEALPRO",
+                                      :currency => "GBP",
+                                      :sec_type => :forex,
+                                      :description => "EURGBP"),
+          
+          :eurjpy => IB::Contract.new(:symbol => "EUR",
+                                      :exchange => "IDEALPRO",
+                                      :currency => "JPY",
+                                      :sec_type => :forex,
+                                      :description => "EURJPY"),
+          
+          :eurusd => IB::Contract.new(:symbol => "EUR",
+                                      :exchange => "IDEALPRO",
+                                      :currency => "USD",
+                                      :sec_type => :forex,
+                                      :description => "EURUSD"),
+                                      
+          :gbpjpy => IB::Contract.new(:symbol => "GBP",
+                                      :exchange => "IDEALPRO",
+                                      :currency => "JPY",
+                                      :sec_type => :forex,
+                                      :description => "GBPJPY"),
+          
+          :gbpusd => IB::Contract.new(:symbol => "GBP",
+                                      :exchange => "IDEALPRO",
+                                      :currency => "USD",
+                                      :sec_type => :forex,
+                                      :description => "GBPUSD"),
+                                      
+          :usdcad => IB::Contract.new(:symbol => "USD",
+                                      :exchange => "IDEALPRO",
+                                      :currency => "CAD",
+                                      :sec_type => :forex,
+                                      :description => "USDCAD"),
+          
+          :usdchf => IB::Contract.new(:symbol => "USD",
+                                      :exchange => "IDEALPRO",
+                                      :currency => "CHF",
+                                      :sec_type => :forex,
+                                      :description => "USDCHF"),
+          
+          :usdjpy => IB::Contract.new(:symbol => "USD",
+                                      :exchange => "IDEALPRO",
+                                      :currency => "JPY",
+                                      :sec_type => :forex,
+                                      :description => "USDJPY"),                                    
+        
+        #-- other pairs (alphabetical order) --
+          :audchf => IB::Contract.new(:symbol => "AUD",
                                       :exchange => "IDEALPRO",
                                       :currency => "CHF",
                                       :sec_type => :forex,
                                       :description => "AUDCHF"),
-
+                                      
+          :audgbp => IB::Contract.new(:symbol => "AUD",
+                                      :exchange => "IDEALPRO",
+                                      :currency => "GBP",
+                                      :sec_type => :forex,
+                                      :description => "AUDGBP"),
+          
           :audjpy => IB::Contract.new(:symbol => "AUD",
                                       :exchange => "IDEALPRO",
                                       :currency => "JPY",
@@ -27,83 +94,53 @@ module IB
                                       :sec_type => :forex,
                                       :description => "AUDNZD"),
 
-          :audusd => IB::Contract.new(:symbol => "AUD",
-                                      :exchange => "IDEALPRO",
-                                      :currency => "USD",
-                                      :sec_type => :forex,
-                                      :description => "AUDUSD"),
-
           :chfjpy => IB::Contract.new(:symbol => "CHF",
                                       :exchange => "IDEALPRO",
                                       :currency => "JPY",
                                       :sec_type => :forex,
                                       :description => "CHFJPY"),
 
-          :gbpjpy => IB::Contract.new(:symbol => "GBP",
-                                      :exchange => "IDEALPRO",
-                                      :currency => "JPY",
-                                      :sec_type => :forex,
-                                      :description => "GBPJPY"),
-
-          :gbpusd => IB::Contract.new(:symbol => "GBP",
-                                      :exchange => "IDEALPRO",
-                                      :currency => "USD",
-                                      :sec_type => :forex,
-                                      :description => "GBPUSD"),
-
-          :eurchf => IB::Contract.new(:symbol => "EUR",
-                                      :exchange => "IDEALPRO",
-                                      :currency => "CHF",
-                                      :sec_type => :forex,
-                                      :description => "EURCHF"),
-
           :euraud => IB::Contract.new(:symbol => "EUR",
                                       :exchange => "IDEALPRO",
                                       :currency => "AUD",
                                       :sec_type => :forex,
                                       :description => "EURAUD"),
-
-          :eurgbp => IB::Contract.new(:symbol => "EUR",
-                                      :exchange => "IDEALPRO",
-                                      :currency => "GBP",
-                                      :sec_type => :forex,
-                                      :description => "EURGBP"),
-
-          :eurjpy => IB::Contract.new(:symbol => "EUR",
-                                      :exchange => "IDEALPRO",
-                                      :currency => "JPY",
-                                      :sec_type => :forex,
-                                      :description => "EURJPY"),
-
-          :eurusd => IB::Contract.new(:symbol => "EUR",
-                                      :exchange => "IDEALPRO",
-                                      :currency => "USD",
-                                      :sec_type => :forex,
-                                      :description => "EURUSD"),
-
+                                      
           :eurcad => IB::Contract.new(:symbol => "EUR",
                                       :exchange => "IDEALPRO",
                                       :currency => "CAD",
                                       :sec_type => :forex,
                                       :description => "EURCAD"),
-
-          :usdchf => IB::Contract.new(:symbol => "USD",
+          
+          :eurhkd => IB::Contract.new(:symbol => "EUR",
                                       :exchange => "IDEALPRO",
-                                      :currency => "CHF",
+                                      :currency => "HKD",
                                       :sec_type => :forex,
-                                      :description => "USDCHF"),
-
-          :usdcad => IB::Contract.new(:symbol => "USD",
+                                      :description => "EURHKD"),
+                                      
+          :eurnzd => IB::Contract.new(:symbol => "EUR",
                                       :exchange => "IDEALPRO",
-                                      :currency => "CAD",
+                                      :currency => "NZD",
                                       :sec_type => :forex,
-                                      :description => "USDCAD"),
-
-          :usdjpy => IB::Contract.new(:symbol => "USD",
+                                      :description => "EURNZD"),
+                                      
+          :usdgbp => IB::Contract.new(:symbol => "USD",
                                       :exchange => "IDEALPRO",
-                                      :currency => "JPY",
+                                      :currency => "GBP",
                                       :sec_type => :forex,
-                                      :description => "USDJPY")
+                                      :description => "USDGBP"),
+                                      
+          :usdhkd => IB::Contract.new(:symbol => "USD",
+                                      :exchange => "IDEALPRO",
+                                      :currency => "HKD",
+                                      :sec_type => :forex,
+                                      :description => "USDHKD"),
+           
+          :usdnzd => IB::Contract.new(:symbol => "USD",
+                                      :exchange => "IDEALPRO",
+                                      :currency => "NZD",
+                                      :sec_type => :forex,
+                                      :description => "USDNZD")                           
         }
       end
     end


### PR DESCRIPTION
I added a few more symbols to forex.rb.  I am making this pull request mostly to make sure that I can do it correctly now.  Prior to making this request I followed your instructions to pull in latest upstream changes.

I added a few symbols to forex.rb.  I also added a comment to bin/market_data.rb to indicate that the forex symbols must be defined in /lib/ib/symbols/forex.rb.  (An explicit comment like that would have saved me some head-scratching when I ran into the previously discussed error.)
