### PR TITLE
added a missing command line option in example/historic_data_cli

### DIFF
--- a/example/historic_data_cli
+++ b/example/historic_data_cli
@@ -19,7 +19,8 @@ opt = Getopt::Long.getopts(
     ["--barsize", REQUIRED],
     ["--csv", BOOLEAN],
     ["--dateformat", REQUIRED],
-    ["--nonregularhours", BOOLEAN]
+    ["--nonregularhours", BOOLEAN],
+    ["--what", OPTIONAL]
 )
 
 if opt["help"] || opt["security"].nil? || opt["security"].empty?


### PR DESCRIPTION
the --what option appeared to be missing from example/historic_data_cli.  I added it in.
