### PR TITLE
use a class instance variable instead of a class variable

### DIFF
--- a/lib/ib/logger.rb
+++ b/lib/ib/logger.rb
@@ -2,7 +2,7 @@ require "logger"
 
 # Add default_logger accessor into Object
 def default_logger
-  @@default_logger ||= Logger.new(STDOUT).tap do |logger|
+  @default_logger ||= Logger.new(STDOUT).tap do |logger|
     time_format = RUBY_VERSION =~ /1\.8\./ ? '%H:%M:%S.%N' : '%H:%M:%S.%3N'
     logger.formatter = proc do |level, time, prog, msg|
 
@@ -13,7 +13,7 @@ def default_logger
 end
 
 def default_logger= logger
-  @@default_logger = logger
+  @default_logger = logger
 end
 
 # Add universally accessible log method/accessor into Object
@@ -22,15 +22,3 @@ def log *args
     logger.fatal *args unless args.empty?
   end
 end
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
I replaced the @@default_logger class variable with a @default_logger class instance variable.  This resolves the Ruby 2.0.0 "class variable access from toplevel" warning ( https://github.com/ib-ruby/ib-ruby/issues/75 ).  I also tested the logger under Ruby 1.9.3; it still works fine with this change.  See also http://thinkrelevance.com/blog/articles/2006/11/16/use-class-instance-variables-not-class-variables
