### PR TITLE
Create snapshot_market_date

### DIFF
--- a/example/snapshot_market_date
+++ b/example/snapshot_market_date
@@ -1,0 +1,97 @@
+#!/usr/bin/env ruby
+##
+## This script connects to IB API and collects snaphot Data for given Contracts
+##
+#
+class Snapshot
+	def initialize 
+		@contracts = Hash.new
+		@prices = Hash.new
+	end
+
+
+	def add_contract id, a_hash, description
+		@contracts[id] = { :contract => IB::Contract.new( a_hash ) , :display_text => description }
+	end
+
+	def print_results
+		@prices.each do |x,y|
+			STDOUT.print "	#{@contracts[x][:display_text] } \t" +
+				y.collect{|x,y| "#{x}: #{y}"}.join(" \n\t\t\t ") +" \n"
+		end
+	end
+
+
+	def process
+		ib =  IB::Connection.current
+		@count =  @contracts.size
+		unless ib.nil?
+			ib.subscribe(:Alert, :TickPrice,:TickSize,:TickString,:TickGeneric,:TickSnapshotEnd) do |msg|
+				if msg.is_a? IB::Messages::Incoming::Alert
+					if msg.code == 354 #Requested market data is not subscribed
+						@count -=1  # wir zählen den Counter runter, so dass
+						puts "No Marketdata Subscription"
+						# am Ende die Orderantwort ausgelöst wird
+					else
+						puts msg.message  # unhandled Alert
+					end
+				else
+					case msg
+					when IB::Messages::Incoming::TickSize
+						#	for debugging purpose
+						#	print @contracts[msg.ticker_id][:display_text], "\t", "size\t", msg.size, "\n"
+
+					when IB::Messages::Incoming::TickPrice
+						if @prices[msg.ticker_id].nil?
+							@prices[msg.ticker_id] = {msg.type => msg.price }
+						else
+							@prices[msg.ticker_id][msg.type]=msg.price
+						end
+					when IB::Messages::Incoming::TickString, IB::Messages::Incoming::TickGeneric
+						#		we ignore this message silently
+					when IB::Messages::Incoming::TickSnapshotEnd
+						@count -=1   
+						print_results if @count.zero?
+					else
+						# unhandled message
+						puts msg.inspect
+					end
+				end
+			end
+
+			@contracts.each do |id, contract_hash |
+
+				ib.send_message :RequestMarketData, 
+												:ticker_id => id, 
+												:contract => contract_hash[:contract],
+												:snapshot => 1
+			end
+		end
+	end
+
+end # class
+
+####  here it starts #######
+
+require 'rubygems'
+require 'bundler/setup'
+$LOAD_PATH.unshift File.expand_path(File.dirname(__FILE__) + '/../lib')
+require 'ib-ruby'
+
+# Set log level
+log.level = Logger::FATAL
+#
+# # Connect to IB TWS
+IB::Connection.new :client_id => 1112 , :port => 7496 # TWS
+
+s = Snapshot.new
+s.add_contract 2, {:con_id => 269120, :exchange => 'SMART'}, 'Fastenal'
+s.add_contract 4, {:symbol => 'IBM', :sec_type=> :stock, :exchange => 'SMART', :currency => 'USD'}, 'IBM'
+s.add_contract 9, {sec_type: "CASH", currency: "USD", exchange: "IDEALPRO",symbol: "EUR"}, "EUR/USD"
+s.process
+
+puts "\n******** Press <Enter> to cancel... *********\n\n"
+STDIN.gets
+
+puts "Once again, the Snapshot-Data"
+s.print_results


### PR DESCRIPTION
Example that gets snapshot-market-data via the IB-API. The »snapshot«-param in the RequestMarketData-event makes is very simple to collect EOD Data (OHCL).
Market-Data Subscription is required for stocks, options and futures.
