### PR TITLE
Update connection.rb

### DIFF
--- a/lib/ib/connection.rb
+++ b/lib/ib/connection.rb
@@ -301,7 +301,7 @@ module IB
     # Place Order (convenience wrapper for send_message :PlaceOrder).
     # Assigns client_id and order_id fields to placed order. Returns assigned order_id.
     def place_order order, contract
-      order.place contract, self
+      order.place contract, self  if order.is_a? IB::Order
     end
 
     # Modify Order (convenience wrapper for send_message :PlaceOrder). Returns order_id.


### PR DESCRIPTION
The »place« wrapper fails if the order is deleted in another thread. This results in a #<NoMethodError: undefined method `place' for nil:NilClass>, which can easily be avoided.
Alternativley a rescue-cause is possible, too.
