### PR TITLE
Fix wrong dependency, ActiveRecord(4.0.1) incompatible with this regexps /^$/

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     ib-ruby (0.9.2)
-      activerecord (>= 3.2.0)
+      activerecord (~> 3.2.0)
       bundler (>= 1.1.3)
       standalone_migrations
       xml-simple (>= 1.1.1)

--- a/ib-ruby.gemspec
+++ b/ib-ruby.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
 
   # Dependencies
   gem.add_dependency 'bundler', '>= 1.1.3'
-  gem.add_dependency 'activerecord', '>= 3.2.0'
+  gem.add_dependency 'activerecord', '~> 3.2.0'
   #gem.add_dependency 'activerecord-jdbcsqlite3-adapter', '>= 1.2.2'
   #gem.add_dependency 'jdbc-sqlite3', '>= 3.7.2'
   gem.add_dependency 'xml-simple', '>= 1.1.1'


### PR DESCRIPTION
 gem.add_dependency 'activerecord', '=> 3.2.0'
Makes bundler install the last activerecord version, that in the moment of writings this is 4.0.0, this activerecord version breaks this gem because of changes in regular expressions see this http://dev.mensfeld.pl/2013/07/upgrading-to-rails-4-0-from-rails-3-2-test-case-part-ii-assets-models/#regexp