### PR TITLE
IB::Connect works in multithreading environment

### DIFF
--- a/example/contract_details
+++ b/example/contract_details
@@ -6,6 +6,7 @@ require 'rubygems'
 require 'bundler/setup'
 $LOAD_PATH.unshift File.expand_path(File.dirname(__FILE__) + '/../lib')
 require 'yaml'
+require 'pp'
 require 'active_support'
 require 'ib-ruby'
 require 'factory_girl'
@@ -37,22 +38,29 @@ IB::Connection.new :client_id => 1112,  :port => 7496 # TWS
 IB::Connection.current.logger.level= 3
 market.each_pair do |id, contract|
   puts "\nRequesting contract data #{id}: #{contract.description}"
-  symbol, min_tick = nil
+  symbol, min_tick, result = nil
+
+  ## A Thread environment is only nessesary, if some other parts of the 
+  ## programm are accessing subscribed messages. This domonstrates the usage.
+  
+  t=Thread.new do
   result=  contract.read_contract_from_tws do |msg|
 	  # Any attribute of the contract-object is assesible, i.e.
 	  symbol=  msg.contract.present? ? msg.contract.symbol : "XXX"
 	  # In Addition, all Contract-Detail-Attributes are present 
 	  min_tick= msg.contract_detail.present? ? msg.contract_detail.min_tick : 0
   end
-
+  end
+  t.join  # wait for the thread to finish  
   puts "Query #{id}-----------------------------------------------------------"
   puts "Result: #{result } \t (local symbol / Nr of Contracts)"
   puts "TWS-resonse: Symbol -> #{symbol}", "Min-Tick:#{min_tick}"
   puts "Updated-Contract"
-  puts  contract.inspect #to_human
+  pp  contract #to_human
   puts "----------------------------------------------------------------------"
   # Request Contract details for the symbols we're interested in. TWS will
   # respond with ContractData messages, which will be processed by the code above.
+  
 end
 rescue RuntimeError => e
 	puts "Error"

--- a/example/contract_details
+++ b/example/contract_details
@@ -19,52 +19,57 @@ FactoryGirl.definition_file_paths=["../spec/factories"]
 FactoryGirl.find_definitions
 
 begin
-market = {"Apple - Manual" => FactoryGirl.build( :ib_contract ), # apple
-          "Molson Coors via Factory" => FactoryGirl.build( :ib_contract, symbol:'TAP') ,
-          "Default Option via Factory"  => FactoryGirl.build( :default_option, expiry:201503 ),
-	  "Default Stock via Factory" => FactoryGirl.build( :default_stock ),
-	  "Fastenal - manual " => IB::Stock.new( symbol:'FAST' ),
-	  "Default Future via Facotry" => FactoryGirl.build( :default_future ),
-	  "S&P Future - Manual"  => IB::Future.new( symbol:'ES', expiry:201512, multiplier:50 , :exchange => 'GLOBEX'),	
-	  "Default Forex via Factory" => FactoryGirl.build( :default_forex ),
-	  "NOK/SEK - Manual" => FactoryGirl.build( :default_forex , symbol:'NOK', currency:'SEK'),
-	  "GE-Option -Manual with multible contracts" => IB::Option.new( symbol:'GE', strike:25, expiry:201501), # multible put-options, only the last ist selected
-	  "Fake Stock via Factory"  => FactoryGirl.build( :default_stock, :symbol=>'FAKE' )  # not a valid symbol
+market = {"1. Apple via Factory" => FactoryGirl.build( :ib_contract ), # apple
+          "2. Molson Coors via Factory" => FactoryGirl.build( :ib_contract, symbol:'TAP', con_id: nil) ,
+          "3. Default Option via Factory"  => FactoryGirl.build( :default_option, expiry:201503 ),
+	  "4. Default Stock via Factory" => FactoryGirl.build( :default_stock ),
+	  "5. Fastenal - manual " => IB::Stock.new( symbol:'FAST' ),
+	  "6. Default Future via Facotry" => FactoryGirl.build( :default_future ),
+	  "7. S&P Future - Manual"  => IB::Future.new( symbol:'ES', expiry:201512,  :exchange => 'GLOBEX'),	
+	  "8. Default Forex via Factory" => FactoryGirl.build( :default_forex ),
+	  "9. NOK/SEK - Manual" => FactoryGirl.build( :default_forex , symbol:'NOK', currency:'SEK'),
+	  "10.GE-Option -Manual with multible contracts" => IB::Option.new( symbol:'GE', strike:25, expiry:201501), # multible put-options, only the last ist selected
+	  "11.Fake Stock via Factory"  => FactoryGirl.build( :default_stock, :symbol=>'FAKE' )  # not a valid symbol
 	}
-#           6 => IB::Symbols::Options[:vxx40] }  #--> osi definition is not supported
 
 # Connect to IB TWS.
 IB::Connection.new :client_id => 1112,  :port => 7496 # TWS
 IB::Connection.current.logger.level= 3
-market.each_pair do |id, contract|
-  puts "\nRequesting contract data #{id}: #{contract.description}"
-  symbol, min_tick, result = nil
+threadArray = Array.new
 
-  ## A Thread environment is only nessesary, if some other parts of the 
-  ## programm are accessing subscribed messages. This domonstrates the usage.
-  
-  t=Thread.new do
-  result=  contract.read_contract_from_tws do |msg|
-	  # Any attribute of the contract-object is assesible, i.e.
-	  symbol=  msg.contract.present? ? msg.contract.symbol : "XXX"
-	  # In Addition, all Contract-Detail-Attributes are present 
-	  min_tick= msg.contract_detail.present? ? msg.contract_detail.min_tick : 0
+3.times do
+  market.each_pair do |id, contract|
+    puts "\nRequesting contract data #{id}: #{contract.description}"
+
+    ## A Thread environment is only nessesary, if some other parts of the 
+    ## programm are accessing subscribed messages. This domonstrates the usage.
+
+    threadArray << Thread.new( contract)  do | contract |
+      # local vars
+      symbol, min_tick, result, con_id = nil
+      result=  contract.read_contract_from_tws do |msg|
+	# Any attribute of the contract-object is assesible, i.e.
+	con_id =  msg.contract.present? ? msg.contract.con_id : "NO CONTRACT"
+	symbol =  msg.contract.present? ? msg.contract.symbol : "XXX"
+	# In Addition, all Contract-Detail-Attributes are present 
+	min_tick= msg.contract_detail.present? ? msg.contract_detail.min_tick : 0
+      end
+      puts "Query #{id}-----------------------------------------------------------"
+      puts "Result: #{result } \t (local symbol / Nr of Contracts)"
+      puts "TWS-resonse: Symbol -> #{symbol}", "Min-Tick:#{min_tick}", "ConID:#{con_id}"
+      puts "Updated-Contract"
+      puts  contract.to_human
+      puts "----------------------------------------------------------------------"
+      # Request Contract details for the symbols we're interested in. TWS will
+      # respond with ContractData messages, which will be processed by the code above.
+
+    end # thread
   end
-  end
-  t.join  # wait for the thread to finish  
-  puts "Query #{id}-----------------------------------------------------------"
-  puts "Result: #{result } \t (local symbol / Nr of Contracts)"
-  puts "TWS-resonse: Symbol -> #{symbol}", "Min-Tick:#{min_tick}"
-  puts "Updated-Contract"
-  pp  contract #to_human
-  puts "----------------------------------------------------------------------"
-  # Request Contract details for the symbols we're interested in. TWS will
-  # respond with ContractData messages, which will be processed by the code above.
-  
 end
+threadArray.each{|t| t.join}  # wait for the threads to finish 
 rescue RuntimeError => e
-	puts "Error"
-	puts e
+  puts "Error"
+  puts e
 end
 
 =begin

--- a/example/contract_details_simple
+++ b/example/contract_details_simple
@@ -1,0 +1,85 @@
+#!/usr/bin/env ruby
+#
+# This script gets details for specific contract from IB
+
+require 'rubygems'
+require 'bundler/setup'
+$LOAD_PATH.unshift File.expand_path(File.dirname(__FILE__) + '/../lib')
+require 'yaml'
+require 'pp'
+require 'active_support'
+require 'ib-ruby'
+# This example 
+# Definition of what we want market data for.  We have to keep track of what ticker id
+# corresponds to what symbol ourselves, because the ticks don't include any other
+# identifying infoormation. The choice of ticker ids is, as far as I can tell, arbitrary.
+
+if  RUBY_VERSION.to_i < 2
+  puts " Ruby 2.x needed "
+  exit
+end
+IB::Connection.new  :recieved=> false, :client_id => 1112,  :port => 7496 # TWS
+if IB::Connection.current.nil?
+  puts "No TWS"
+  exit
+end
+IB::Connection.current.logger.level= 3
+
+market = {"1. Apple	 " =>  IB::Stock.new(  symbol: 'AAPL') ,
+          "2. BASF	 " =>  IB::Stock.new(  symbol: 'BAS', currency: 'EUR'  ) ,
+          "3. DSB	 " =>  IB::Stock.new(  symbol: 'D05', currency: 'SGD', exchange: 'SGX'  ) ,
+	  "7. S&P Future " =>  IB::Future.new( symbol: 'ES',  expiry:201512,   exchange: 'GLOBEX'),	
+	  "9. NOK/SEK	 " =>  IB::Forex.new(  symbol: 'NOK', currency:'SEK'),
+	  "10. GE-Option " =>  IB::Option.new( symbol: 'GE',  strike:25,       expiry:201503), #  put+call-options, only the last is selected
+	  "11. Fake Stock" =>  IB::Stock.new( :symbol=>'FAKE' )  # not a valid symbol
+
+	}
+
+# Connect to IB TWS.
+market.each_pair do |id, contract|
+  puts "\nRequesting contract data #{id}: #{contract.description}"
+  result = nil
+
+  ## A Thread environment is only nessesary, if some other parts of the 
+  ## programm are accessing subscribed messages. This domonstrates the usage.
+
+  symbol,con_id,min_tick=0
+  result=  contract.read_contract_from_tws do |msg|
+    # Any attribute of the contract-object is assesible, i.e.
+    symbol= msg.contract.present? ? msg.contract.symbol : "XXX"
+    con_id= msg.contract.present? ? msg.contract.con_id : "NO CONID"
+    # In Addition, all Contract-Detail-Attributes are present 
+    min_tick= msg.contract_detail.present? ? msg.contract_detail.min_tick : 0
+    puts "Query #{id}-----------------------------------------------------------"
+    puts "TWS-resonse: Symbol -> #{symbol}", "Min-Tick:#{min_tick}, ConId:#{con_id}"
+  end
+  puts "Result: #{result } \t\t (local symbol / Nr of Contracts)"
+  puts "Updated-Contract  \t #{contract.to_human}"
+  puts "-"*25
+  # Request Contract details for the symbols we're interested in. TWS will
+  # respond with ContractData messages, which will be processed by the code above.
+
+end
+IB::Connection.current.disconnect
+sleep 1
+=begin
+Requesting contract data : EURUSD
+TWS-Response:
+<Contract: {"symbol"=>"EUR", "sec_type"=>"CASH", "expiry"=>"", "strike"=>0.0,
+"right"=>"", "exchange"=>"IDEALPRO", "currency"=>"USD",
+"local_symbol"=>"EUR.USD", "con_id"=>12087792, "multiplier"=>0,
+"primary_exchange"=>"", "created_at"=>2015-01-03 16:26:26 +0100,
+"updated_at"=>2015-01-03 16:26:26 +0100, "include_expired"=>false} >
+ . . . . . . . . . ContractDetails. . . . . . . . . . . . . . 
+ {"market_name"=>"EUR.USD", "trading_class"=>"EUR.USD", "min_tick"=>5.0e-05,
+ "order_types"=>"ACTIVETIM,ADJUST,ALERT,ALGO,ALLOC,AVGCOST,BASKET,COND,CONDORDER,DAY,DEACT,DEACTDIS,DEACTEOD,GAT,GTC,GTD,GTT,HID,IOC,LIT,LMT,MIT,MKT,NONALGO,OCA,REL,SCALE,SCALERST,STP,STPLMT,TRAIL,TRAILLIT,TRAILLMT,TRAILMIT,WHATIF,",
+ "valid_exchanges"=>"IDEALPRO", "price_magnifier"=>1, "under_con_id"=>0,
+ "long_name"=>"European Monetary Union Euro", "contract_month"=>"",
+ "industry"=>"", "category"=>"", "subcategory"=>"", "time_zone"=>"EST5EDT",
+ "trading_hours"=>"20150103:CLOSED;20150105:1715-1700",
+ "liquid_hours"=>"20150103:CLOSED;20150105:1715-1700", "ev_rule"=>0.0,
+ "ev_multiplier"=>"", "sec_id_list"=>{}, "created_at"=>2015-01-03 16:26:26
+ +0100, "updated_at"=>2015-01-03 16:26:26 +0100, "coupon"=>0.0,
+ "callable"=>false, "puttable"=>false, "convertible"=>false,
+ "next_option_partial"=>false}
+=end

--- a/lib/ib/tws_reader.rb
+++ b/lib/ib/tws_reader.rb
@@ -1,5 +1,5 @@
 module IB
-	module TWS_Reader
+  module TWS_Reader
 =begin
 Generates an IB::Contract with the required attributes to retrieve a unique contract from the TWS
 
@@ -9,42 +9,42 @@ So – even to update its contents, a defined subset of query-parameters  have t
 The required data-fields are stored in a yaml-file.
 If the con_id is present, only con_id and exchange are transmitted to the tws.
 =end
-	def  query_contract invalid_record:true
-		## the yml presents symbol-entries
-		## these are converted to capitalized strings 
-		items_as_string = ->(i){i.map{|x,y| x.to_s.capitalize}.join(', ')}
-		## here we read the corresponding attributes of the specified contract 
-		item_values = ->(i){ i.map{|x,y| self.send(x).presence || y }}
-		## and finally we create a attribute-hash to instantiate a new Contract
-		## to_h is present only after ruby 2.1.0
-		item_attributehash = ->(i){ i.keys.zip(item_values[i]).to_h }
-		## now lets proceed, but only if no con_id is present
-		nessesary_items = YAML.load_file(yml_file)[sec_type]
-		ret_var= if con_id.nil?  || con_id.zero?
+    def  query_contract invalid_record:true
+      ## the yml presents symbol-entries
+      ## these are converted to capitalized strings 
+      items_as_string = ->(i){i.map{|x,y| x.to_s.capitalize}.join(', ')}
+      ## here we read the corresponding attributes of the specified contract 
+      item_values = ->(i){ i.map{|x,y| self.send(x).presence || y }}
+      ## and finally we create a attribute-hash to instantiate a new Contract
+      ## to_h is present only after ruby 2.1.0
+      item_attributehash = ->(i){ i.keys.zip(item_values[i]).to_h }
+      ## now lets proceed, but only if no con_id is present
+      nessesary_items = YAML.load_file(yml_file)[sec_type]
+      ret_var= if con_id.nil?  || con_id.zero?
 
-			raise "#{items_as_string[nessesary_items]} are needed to retrieve Contract, got: #{item_values[nessesary_items].join(',')}" if item_values[nessesary_items].any?( &:nil? ) 
-			IB::Contract.new  item_attributehash[nessesary_items].merge(:sec_type=> sec_type)
-			else 
-			IB::Contract.new  con_id:con_id , :exchange => exchange.presence || item_attributehash[nessesary_items][:exchange]
-		end  # if
-		## modify the Object, ie. set con_id to zero
-		if new_record?
-			self.con_id=0
-		else
-			update_attribute( :con_id,  0 )
-		end if invalid_record
-		ret_var
+		 raise "#{items_as_string[nessesary_items]} are needed to retrieve Contract, got: #{item_values[nessesary_items].join(',')}" if item_values[nessesary_items].any?( &:nil? ) 
+		 IB::Contract.new  item_attributehash[nessesary_items].merge(:sec_type=> sec_type)
+	       else 
+		 IB::Contract.new  con_id:con_id , :exchange => exchange.presence || item_attributehash[nessesary_items][:exchange]
+	       end  # if
+      ## modify the Object, ie. set con_id to zero
+      if new_record?
+	self.con_id=0
+      else
+	update_attribute( :con_id,  0 )
+      end if invalid_record
+      ret_var
 
-		
 
-	end # def
+
+    end # def
 =begin
 by default, the yml-file in the base-directory (ib-ruby) is used.
 This method can be overloaded to include a file from a different location
 =end
-		def yml_file
-			File.expand_path('../../../contract_config.yml',__FILE__ )
-		end
+    def yml_file
+      File.expand_path('../../../contract_config.yml',__FILE__ )
+    end
 =begin
 read_contract_from_tws (alias update_contract) requests ContractData from the TWS and
 stores/updates them in this contract_object.
@@ -62,8 +62,8 @@ Example:
 	given an active-record-Model with min_tick-attribute:
 	--------------------------------------------------
 	contract = IB::Contract.find x
-        count_datasets,lth = 0
-        contract.update_contract do |msg|
+	count_datasets,lth = 0
+	contract.update_contract do |msg|
 	    update_attibute :min_tic , msg.contractdetail.min_tick
 	    count_datasets +=1
 	    lth= msg.contractdetail.liquid_trading_hours
@@ -82,106 +82,107 @@ i.e.
 
 
 =end
-	def read_contract_from_tws unique: true, save_details: false
+    def read_contract_from_tws unique: true, save_details: false
 
-		ib = IB::Connection.current
-		raise "NO TWS" unless ib.present?
-		to_be_saved = IB.db_backed? && !new_record?
+      ib = IB::Connection.current
+      raise "NO TWS" unless ib.present?
+      to_be_saved = IB.db_backed? && !new_record?
 
-		# if it's a not-saved object, we generate an Request-Message-ID on the fly
-		# otherwise the Object.id is used as Message-ID and the database is updated 
-		# after the query
-		#
-		message_id =  if !to_be_saved
-				      random = 1.times.inject([]) {|r| v = rand(200) until v and not r.include? v; r << v}.pop 			
-				      random + ( IB::Contract.maximum(:id).presence||1 )  rescue random ## return_value
-			      else
-				      id
-			      end
-		# define loacl vars which are updated within the follwoing block
-		exitcondition, count = false, 0
+      # if it's a not-saved object, we generate an Request-Message-ID on the fly
+      # otherwise the Object.id is used as Message-ID and the database is updated 
+      # after the query
+      #
+      message_id =  if !to_be_saved
+		      random = 1.times.inject([]) {|r| v = rand(200) until v and not r.include? v; r << v}.pop 			
+		      random + ( IB::Contract.maximum(:id).presence||1 )  rescue random ## return_value
+		    else
+		      id
+		    end
+      # define loacl vars which are updated within the follwoing block
+      exitcondition, count = false, 0
 
-		wait_until_exitcondition = -> do 
-			u=0; while u<100  do   # wait max 5 sec
-				break if exitcondition 
-				u+=1; sleep 0.05 
-			end
-		end
-		
-		attributes_to_be_transfered = ->(obj) do
-			obj.attributes.reject{|x,y| ["created_at","updated_at","id"].include? x }
-		end
-			
-		# subscribe to ib-messages and describe what to do
-		a = ib.subscribe(:Alert, :ContractData,  :ContractDataEnd) do |msg| 
-			case msg
-			when IB::Messages::Incoming::Alert
-				if msg.code==200 && msg.error_id==message_id
-					warn { "Not a valid Contract :: #{self.to_human} " }
-					# save message to local_symbol
-				    if to_be_saved 
-				      update_attribute( :local_symbol,  msg.message ) 
-				      # Process is part of asyncronous Communication from TWS
-				      ActiveRecord::Base.connection.close
-				      else
-				    self.local_symbol= msg.message 
-				      end
+      wait_until_exitcondition = -> do 
+	u=0; while u<100  do   # wait max 5 sec
+	  break if exitcondition 
+	  u+=1; sleep 0.05 
+	end
+	end
 
-					exitcondition = true
-					# alternative
-			#		raise 'Not a valid Contract '
-				else
-					puts msg.to_human 
-				end
-			when IB::Messages::Incoming::ContractData
-				if msg.request_id.to_i ==  message_id
-					# if multible contracts are present, all of them are assigned
-					# Only the last contract is returned. However 'count' is incremented
-					count +=1
-	warn{ "Multible Contracts are detected, only the last is returned, this one is overridden -->#{self.to_human} "} if count>1
-					## a specified block gets the msg-object on any uniq ContractData-Event
-					yield msg if block_given?
-					if to_be_saved 
-						update attributes_to_be_transfered[msg.contract]
-						if contract_detail.nil?
-						self.contract_detail =  msg.contract_detail 
-						else
-						contract_detail.update attributes_to_be_transfered[msg.contract_detail] ## AR4 specific
-						end if save_details
-						# Process is part of asyncronous Communication from TWS
-						ActiveRecord::Base.connection.close
+	attributes_to_be_transfered = ->(obj) do
+	  obj.attributes.reject{|x,y| ["created_at","updated_at","id"].include? x }
+	end
 
-					else
-						self.attributes =  msg.contract.attributes  # AR4 specific
+	# subscribe to ib-messages and describe what to do
+	a = ib.subscribe(:Alert, :ContractData,  :ContractDataEnd) do |msg| 
+	  case msg
+	  when IB::Messages::Incoming::Alert
+	    if msg.code==200 && msg.error_id==message_id
+	      ib.logger.warn { "Not a valid Contract :: #{self.to_human} " }
+	      # save message to local_symbol
+	      if to_be_saved 
+		update_attribute( :local_symbol,  msg.message ) 
+		# Process is part of asyncronous Communication from TWS
+		ActiveRecord::Base.connection.close
+	      else
+		self.local_symbol= msg.message 
+	      end
 
-					end
-				end
-			when IB::Messages::Incoming::ContractDataEnd
-				exitcondition = true if msg.request_id.to_i ==  message_id
+	      exitcondition = true
+	      # alternative
+	      #		raise 'Not a valid Contract '
+	    else
+	      ib.logger.debug  { msg.to_human }
+	    end
+	  when IB::Messages::Incoming::ContractData
+	    if msg.request_id.to_i ==  message_id
+	      # if multible contracts are present, all of them are assigned
+	      # Only the last contract is returned. However 'count' is incremented
+	      count +=1
+	      ib.logger.warn{ "Multible Contracts are detected, only the last is returned, this one is overridden -->#{self.to_human} "} if count>1
+	      ## a specified block gets the msg-object on any uniq ContractData-Event
+	      yield msg if block_given?
+	      if to_be_saved 
+		update attributes_to_be_transfered[msg.contract]
+		if contract_detail.nil?
+		  self.contract_detail =  msg.contract_detail 
+		else
+		  contract_detail.update attributes_to_be_transfered[msg.contract_detail] ## AR4 specific
+		end if save_details
+		# Process is part of asyncronous Communication from TWS
+		ActiveRecord::Base.connection.close
 
-			end  # case
-		end # subscribe
+	      else
+		self.attributes =  msg.contract.attributes  # AR4 specific
 
-		### send the request !
-		begin
-		ib.send_message :RequestContractData, 
-			:id => new_record? ? message_id : id,
-			:contract => ( unique ? query_contract : self  rescue self )  # prevents error if Ruby vers < 2.1.0
-		# we do not rely on the received hash, we simply wait for the ContractDataEnd Event 
-		# (or 5 sec). 
-		wait_until_exitcondition[]
-		ib.unsubscribe a
-		rescue ThreadError => e
-		  puts "TWS_reader#read_contract_from_TWS:..:ThreadERROR"
-		  puts e.inspect
-		  raise
-		end
-		
-		warn{ "NO Contract returned by TWS -->#{self.to_human} "} unless exitcondition
-		warn{ "Multible Contracts are detected, only the last is returned -->#{contract.to_human} "} if count>1
-		count>1 ? count : local_symbol # return_value
-	end # def
+	      end
+	    end
+	  when IB::Messages::Incoming::ContractDataEnd
+	    exitcondition = true if msg.request_id.to_i ==  message_id
 
-  	alias update_contract read_contract_from_tws
-end # module
-end # module
+	  end  # case
+	end # subscribe
+
+	### send the request !
+	begin
+	  ib.send_message :RequestContractData, 
+	    :id => new_record? ? message_id : id,
+	    :contract => ( unique ? query_contract : self  rescue self )  # prevents error if Ruby vers < 2.1.0
+	  # we do not rely on the received hash, we simply wait for the ContractDataEnd Event 
+	  # (or 5 sec). 
+	  wait_until_exitcondition[]
+	  ib.unsubscribe a
+	  ## monitor deadlocks 
+	rescue ThreadError => e
+	  puts "TWS_reader#read_contract_from_TWS:..:ThreadERROR"
+	  puts e.inspect
+	  raise
+	end
+
+	ib.logger.warn{ "NO Contract returned by TWS -->#{self.to_human} "} unless exitcondition
+	ib.logger.warn{ "Multible Contracts are detected, only the last is returned -->#{contract.to_human} "} if count>1
+	count>1 ? count : local_symbol # return_value
+      end # def
+
+      alias update_contract read_contract_from_tws
+    end # module
+  end # module

--- a/lib/ib/tws_reader.rb
+++ b/lib/ib/tws_reader.rb
@@ -111,7 +111,13 @@ Example:
 				if msg.code==200 && msg.error_id==message_id
 					warn { "Not a valid Contract :: #{self.to_human} " }
 					# save message to local_symbol
-				 to_be_saved ? update_attribute( :local_symbol,  msg.message ) : self.local_symbol= msg.message 
+				    if to_be_saved 
+				      update_attribute( :local_symbol,  msg.message ) 
+				      # Process is part of asyncronous Communication from TWS
+				      ActiveRecord::Base.connection.close
+				      else
+				    self.local_symbol= msg.message 
+				      end
 
 					exitcondition = true
 					# alternative
@@ -134,6 +140,9 @@ Example:
 						else
 						contract_detail.update attributes_to_be_transfered[msg.contract_detail] ## AR4 specific
 						end if save_details
+						# Process is part of asyncronous Communication from TWS
+						ActiveRecord::Base.connection.close
+
 					else
 						self.attributes =  msg.contract.attributes  # AR4 specific
 
@@ -155,7 +164,7 @@ Example:
 		wait_until_exitcondition[]
 		ib.unsubscribe a
 		rescue ThreadError => e
-		  puts "ERROR"
+		  puts "TWS_reader#read_contract_from_TWS:..:ThreadERROR"
 		  puts e.inspect
 		  raise
 		end

--- a/lib/models/ib/contract.rb
+++ b/lib/models/ib/contract.rb
@@ -97,8 +97,8 @@ module IB
       ### Extra validations
 ## Ths validation is missleading because a query with con_id and currency is valid
 ## better: create IB::Future, IB::Stock, IB::Forex and IB::Bond models
-      validates_inclusion_of :sec_type, :in => CODES[:sec_type].keys,
-      :message => "should be valid security type"
+    #  validates_inclusion_of :sec_type, :in => CODES[:sec_type].keys,
+#      :message => "should be valid security type"
 
     validates_format_of :expiry, :with => /\A\d{6}$|^\d{8}$|\A\z/,
       :message => "should be YYYYMM or YYYYMMDD"
@@ -111,11 +111,13 @@ module IB
 
     validates_numericality_of :multiplier, :strike, :allow_nil => true
 
+#    validates_uniqueness_of :con_id, :allow_nil => true  ## has to be defined in model, too
+
     def default_attributes
-      super.merge :con_id => 0,
-        :strike => 0.0,
+      super.merge :strike => 0.0,
+      #:con_id =>  0 --> then validation (s.o) is impossible
         :right => :none, # Not an option
-#        :exchange => 'SMART',  --> overload in IB::Stock, IB::Option, IB::Future, IB::Forex
+#        :exchange => 'SMART',  --> specified in IB::Stock, IB::Option, IB::Future, IB::Forex
         :include_expired => false
     end
 

--- a/spec/models/ib/contract_spec.rb
+++ b/spec/models/ib/contract_spec.rb
@@ -164,7 +164,6 @@ let( :ford_option_3){ FactoryGirl.build(:default_option, strike: 16)}
   end #serialization
 
 
-
   describe 'tws_reader' do
 	  before { IB::Connection.new( OPTS[:connection].merge(:logger => mock_logger)) if IB::Connection.current.nil? }
 	let( :list_of_stocks )  { ["BAP","LNN","T","MSFT","GE"] }
@@ -244,4 +243,34 @@ let( :ford_option_3){ FactoryGirl.build(:default_option, strike: 16)}
 #		  end # descirbe FG
 #	  end
 	end # describe tws_reader
+
+  describe 'database inteactions' , focus:true do
+
+    context "without a given ConID" do
+    let ( :stock ){ FactoryGirl.build( :default_stock ) }
+
+    it " can be saved " do
+      expect{ stock.save}.to change{ IB::Contract.count }.by(1)
+    end
+    it " can  be saved twice " do
+      expect{ 2.times{ stock.dup.save} }.to change{ IB::Contract.count }.by 2
+    end
+
+    context "with a giben ConID" do
+    let ( :stock ){IB::Contract.new con_id: 265598  }
+
+    it " can be saved " do
+      expect{ stock.save}.to change{ IB::Contract.count }.by(1)
+    end
+    it " cannot  be saved twice " do
+    anotherstock = IB::Contract.new con_id: 265598
+      expect{ 2.times{ stock.dup.save} }.not_to change{ IB::Contract.count }
+      expect{ anotherstock.save }.to raise_error(RuntimeError)
+    end
+
+    end
+  end
+
+  end
+
 end # describe IB::Contract


### PR DESCRIPTION
The previous realisation of IB::Connect#send_message failed if the messages are generated in parallel + independend threads. 
By using a Mutex its garanteed that the messages send to the tws are provided sequencially.