### PR TITLE
Automatically terminate execution of example/historic_data once all data is received

### DIFF
--- a/example/historic_data
+++ b/example/historic_data
@@ -16,10 +16,7 @@ require 'ib-ruby'
 }
 
 # Connect to IB TWS.
-ib = IB::Connection.new :client_id => 1112 #, :port => 7496 # TWS
-
-# Subscribe to TWS alerts/errors
-ib.subscribe(:Alert) { |msg| puts msg.to_human }
+ib = IB::Connection.new :client_id => 1112, :port => 7496 # TWS
 
 # Subscribe to HistoricalData incoming events.  The code passed in the block
 # will be executed when a message of that type is received, with the received
@@ -27,9 +24,21 @@ ib.subscribe(:Alert) { |msg| puts msg.to_human }
 #
 # Note that we have to look the ticker id of each incoming message
 # up in local memory to figure out what it's for.
-ib.subscribe(IB::Messages::Incoming::HistoricalData) do |msg|
-  puts @contracts[msg.request_id].description + ": #{msg.count} items:"
-  msg.results.each { |entry| puts "  #{entry}" }
+#
+# We also keep track of which contracts we've received messages for, and (below)
+# assume execution is complete once all contracts have received data.
+responded = []
+ib.subscribe([IB::Messages::Incoming::HistoricalData, :Alert]) do |msg|
+  if @contracts.has_key?(msg.request_id)
+    if msg.is_a?(IB::Messages::Incoming::HistoricalData)
+      puts @contracts[msg.request_id].description + ": #{msg.count} items:"
+      puts msg.to_human
+      msg.results.each { |entry| puts "  #{entry}" }
+    else
+      puts msg.to_human + " #{msg.request_id}"
+    end
+    responded << msg.request_id
+  end
 end
 
 # Now we actually request historical data for the symbols we're interested in. TWS will
@@ -46,7 +55,6 @@ end
                       :format_date => 1)
 end
 
-# IB does not send any indication when all historic data is done being delivered.
-# So we need to interrupt manually when our request is answered.
-puts "\n******** Press <Enter> to exit... *********\n\n"
-STDIN.gets
+# Assume execution is complete once we've received a message of some type for each contract.
+sleep(0.2) while responded.length < @contracts.length
+ib.disconnect

--- a/lib/ib/connection.rb
+++ b/lib/ib/connection.rb
@@ -114,6 +114,19 @@ module IB
 
     ### Working with message subscribers
 
+    def resolve_subscription_type(what)
+      case
+        when what.is_a?(Class) && what < Messages::Incoming::AbstractMessage
+          [what]
+        when what.is_a?(Symbol)
+          [Messages::Incoming.const_get(what)]
+        when what.is_a?(Regexp)
+          Messages::Incoming::Classes.values.find_all { |klass| klass.to_s =~ what }
+        else
+          error "#{what} must represent incoming IB message class", :args
+      end
+    end
+
     # Subscribe Proc or block to specific type(s) of incoming message events.
     # Listener will be called later with received message instance as its argument.
     # Returns subscriber id to allow unsubscribing
@@ -127,14 +140,10 @@ module IB
         args.each do |what|
           message_classes =
           case
-          when what.is_a?(Class) && what < Messages::Incoming::AbstractMessage
-            [what]
-          when what.is_a?(Symbol)
-            [Messages::Incoming.const_get(what)]
-          when what.is_a?(Regexp)
-            Messages::Incoming::Classes.values.find_all { |klass| klass.to_s =~ what }
+          when what.is_a?(Array)
+            what.collect { |w| resolve_subscription_type(w) }
           else
-            error "#{what} must represent incoming IB message class", :args
+            resolve_subscription_type(what)
           end
           message_classes.flatten.each do |message_class|
             # TODO: Fix: RuntimeError: can't add a new key into hash during iteration

--- a/lib/ib/connection.rb
+++ b/lib/ib/connection.rb
@@ -114,6 +114,7 @@ module IB
 
     ### Working with message subscribers
 
+    # Given a Class, symbol or regex, return the corresponding Incoming Message class
     def resolve_subscription_type(what)
       case
         when what.is_a?(Class) && what < Messages::Incoming::AbstractMessage

--- a/lib/ib/messages/incoming/abstract_message.rb
+++ b/lib/ib/messages/incoming/abstract_message.rb
@@ -93,6 +93,28 @@ module IB
           end
         end
 
+        # Convert an array of message class identifiers to IncomingMessage
+        # classes.  Accepts any combination of Array, symbol, or regex.
+        # Returns an array of class objects.
+        def self.resolve_message_classes(args)
+          message_classes = []
+          args = [args] unless args.is_a?(Array)
+          args.flatten.each do |what|
+            message_classes <<
+              case
+              when what.is_a?(Class) && what < Messages::Incoming::AbstractMessage
+                what
+              when what.is_a?(Symbol)
+                Messages::Incoming.const_get(what)
+              when what.is_a?(Regexp)
+                Messages::Incoming::Classes.values.find_all { |klass| klass.to_s =~ what }
+              else
+                error "#{what} must represent incoming IB message class", :args
+              end
+          end
+          message_classes.flatten
+        end
+
       end # class AbstractMessage
     end # module Incoming
   end # module Messages

--- a/lib/ib/messages/incoming/alert.rb
+++ b/lib/ib/messages/incoming/alert.rb
@@ -9,6 +9,8 @@ module IB
                                                  [:code, :int],
                                                  [:message, :string])
       class Alert
+        alias_method :request_id, :error_id
+
         # Is it an Error message?
         def error?
           code < 1000

--- a/spec/ib/messages/incoming/abstract_message_spec.rb
+++ b/spec/ib/messages/incoming/abstract_message_spec.rb
@@ -1,0 +1,44 @@
+require 'message_helper'
+
+describe IB::Messages::Incoming::AbstractMessage do
+
+  describe '#resolve_message_classes' do
+
+    it 'should be able to resolve classes' do
+      m = IB::Messages::Incoming::AbstractMessage.resolve_message_classes(IB::Messages::Incoming::HistoricalData)
+      m.length.should == 1
+      m.should include(IB::Messages::Incoming::HistoricalData)
+    end
+
+    it 'should be able to resolve symbols' do
+      m = IB::Messages::Incoming::AbstractMessage.resolve_message_classes(:Alert)
+      m.length.should == 1
+      m.should include(IB::Messages::Incoming::Alert)
+    end
+
+    it 'should be able to resolve regexes' do
+      m = IB::Messages::Incoming::AbstractMessage.resolve_message_classes(/.+Data$/)
+      m.length.should == 6
+      m.should include(IB::Messages::Incoming::ScannerData)
+    end
+
+    it 'should be able to resolve arrays' do
+      m = IB::Messages::Incoming::AbstractMessage.resolve_message_classes([:Alert, IB::Messages::Incoming::HistoricalData])
+      m.length.should == 2
+      m.should include(IB::Messages::Incoming::HistoricalData)
+      m.should include(IB::Messages::Incoming::Alert)
+    end
+
+    
+    it 'should raise when unable to resolve to a class' do
+      expect { IB::Messages::Incoming::AbstractMessage.resolve_message_classes(:nonsense) }.to raise_error
+    end
+
+    it 'should be able to resolve complex combinations of parameters' do
+      m = IB::Messages::Incoming::AbstractMessage.resolve_message_classes([:Alert, [IB::Messages::Incoming::HistoricalData, IB::Messages::Incoming::ScannerData], /::ContractData$/])
+      m.length.should == 4
+    end
+    
+  end
+  
+end


### PR DESCRIPTION
Exit historic_data once a response (of any kind) is received for each request that was sent.
