### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You've been warned.
 
 This code is not sanctioned or supported by Interactive Brokers.
 
-##ANNOUNCE:
+## ANNOUNCE:
 Checkout Branch »Gateway«  for support of FA-(aka Friends & Family)-Accounts.
 Its a release-candidate for Version 0.9.3
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
