### PR TITLE
Avoid spin loop that chews up CPU when TWS is shut down

### DIFF
--- a/lib/ib/connection.rb
+++ b/lib/ib/connection.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 require 'thread'
 require 'active_support'
 require 'ib/socket'
@@ -278,10 +279,22 @@ module IB
       time_out = Time.now + poll_time/1000.0
       while (time_left = time_out - Time.now) > 0
         # If socket is readable, process single incoming message
-        process_message if select [socket], nil, nil, time_left
+        if select [socket], nil, nil, time_left
+          # Peek at the message from the socket; if it's blank then the
+          # server side of connection (TWS) has likely shut down.
+          socket_likely_shutdown = socket.recvmsg(100, Socket::MSG_PEEK)[0] == ""
+
+          # We go ahead process messages regardless (a no-op if socket_likely_shutdown).
+          process_message
+          
+          # After processing, if socket has shut down we sleep for 100ms
+          # to avoid spinning in a tight loop. If the server side somehow
+          # comes back up (gets reconnedted), normal processing
+          # (without the 100ms wait) should happen.
+          sleep(0.1) if socket_likely_shutdown
+        end
       end
     end
-
 
     ### Sending Outgoing messages to IB
 
@@ -369,6 +382,7 @@ module IB
 	end
       end
     end
+    
     # Start reader thread that continuously reads messages from @socket in background.
     # If you don't start reader, you should manually poll @socket for messages
     # or use #process_messages(msec) API.


### PR DESCRIPTION
The message processing loop of IB::Connection would spin in a very tight loop consuming lots of CPU resources on a Mac after TWS was shut down. Added some code to peek at socket contents and sleep for 100ms if the message from the server is blank (""); this indicates that TWS has shut down and we need to pause for a bit to "breathe".