### PR TITLE
Fix Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,10 @@ PATH
   remote: .
   specs:
     ib-ruby (0.9.7.2)
+      activemodel
+      activesupport
       bundler (>= 1.1.16)
+      ox
 
 GEM
   remote: https://rubygems.org/
@@ -98,8 +101,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activemodel
-  activesupport
   getopt
   guard
   guard-rspec


### PR DESCRIPTION
It seems bundle install has not been executed for a while;  which
results in bundle install fetching new version of activemodel and
activesupport getting installed whenever I execute `bundle install` on
the master branch, changing Gemfile.lock file.

This commit reflects current Gem dependency to Gemfile.lock so that
bundle install will not modify Gemfile.lock